### PR TITLE
Allow passing options to placement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ end ),
 ```
 
 The following parameters are accepted:  
-`handy(prog, placement, width, height, screen)`
+`handy(prog, placement, width, height, options, screen)`
 
 - `prog`: the only mandatory parameter, the command to run
 - `placement`: controls the position of the window, see [`awful.placement`](https://awesomewm.org/apidoc/libraries/awful.placement.html)
 - `width`, `height`: the size of the program. Values ≤ 1 are interpreted as
   percentage of screen size, values above 1 are interpreted as pixel sizes
+- `options`: arguments passed to awful.placement
 - `screen`: the screen to use. if not given, defaults to the currently focused
   screen, so each screen will have its own instance

--- a/init.lua
+++ b/init.lua
@@ -14,14 +14,14 @@ local clients = {}
 awesome.register_xproperty("handy_id", "string")
 awesome.register_xproperty("handy_visible", "boolean")
 
-local function spawn_callback(handy_id, placement, screen)
+local function spawn_callback(handy_id, placement, options, screen)
 	return function(c)
 		c:set_xproperty("handy_id", handy_id)
 		clients[screen][handy_id] = c
 
 		-- workaround for awesomeWM/awesome#1937
 		c:connect_signal("focus", function (c)
-			placement(c)
+			placement(c, options)
 		end)
 
 		-- remove clients that were closed
@@ -64,10 +64,11 @@ end
 
 -- Create a new window for the drop-down application when it doesn't
 -- exist, or toggle between hidden and visible states when it does
-local function toggle(prog, placement, width, height, screen)
+local function toggle(prog, placement, width, height, options, screen)
 	local place = placement or awful.placement.centered
 	local w = width or 0.5
 	local h = height or 0.5
+    local opt = options or {}
 	local s = screen or awful.screen.focused()
 
 	if w <= 1 then w = s.geometry.width * w end
@@ -82,7 +83,7 @@ local function toggle(prog, placement, width, height, screen)
 		local properties = { width = w, height = h, floating = true, ontop = true }
 		if restore_client(prog, s, properties) then return end
 
-		awful.spawn(prog, properties, spawn_callback(prog, placement , s))
+		awful.spawn(prog, properties, spawn_callback(prog, placement, opt, s))
 	end
 end
 


### PR DESCRIPTION
Mainly to avoid overlapping of wiboxes. e.g.: 

    handy("app", awful.placement.top_right, w, h, {honor_workarea = true})